### PR TITLE
Add JWT auth-based logout functionality and integration tests

### DIFF
--- a/apps/gd-main-app/core/decorators/swagger-settings/logout.swagger.decorator.ts
+++ b/apps/gd-main-app/core/decorators/swagger-settings/logout.swagger.decorator.ts
@@ -1,0 +1,18 @@
+import { applyDecorators, HttpStatus } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ErrorResponseDto } from '@common';
+
+export function LogoutSwagger() {
+  return applyDecorators(
+    ApiOperation({ summary: 'User Logout.' }),
+    ApiResponse({
+      status: HttpStatus.NO_CONTENT,
+      description: 'Logout successful, no content returned',
+    }),
+    ApiResponse({
+      status: HttpStatus.UNAUTHORIZED,
+      type: ErrorResponseDto,
+      description: 'Logout failed. User is not authenticated.',
+    })
+  );
+}

--- a/apps/gd-main-app/core/guards/local/jwt-auth-guard.ts
+++ b/apps/gd-main-app/core/guards/local/jwt-auth-guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/apps/gd-main-app/core/guards/local/jwt.strategy.ts
+++ b/apps/gd-main-app/core/guards/local/jwt.strategy.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { PassportStrategy } from '@nestjs/passport';
+import { AppConfigService } from '@common';
+
+import { JwtPayloadType } from '../../types/token.types';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
+  constructor(
+    private readonly configService: AppConfigService,
+  ) {
+    const jwtAccessSecret = configService.jwtAccessSecret
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: jwtAccessSecret
+    });
+  }
+
+  async validate(payload: JwtPayloadType) {
+    return {
+      id: payload.id
+    }
+  }
+}

--- a/apps/gd-main-app/src/modules/auth/auth.module.ts
+++ b/apps/gd-main-app/src/modules/auth/auth.module.ts
@@ -13,6 +13,7 @@ import { LocalStrategy } from '../../../core/guards/local/local.strategy';
 import { JwtModule } from '@nestjs/jwt';
 import { AuthService } from './application/auth.service';
 import { PassportModule } from '@nestjs/passport';
+import { JwtStrategy } from '../../../core/guards/local/jwt.strategy';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { PassportModule } from '@nestjs/passport';
     AuthService,
     TokenService,
     LocalStrategy,
+    JwtStrategy,
     UserCreatedListener,
     NotificationService,
     AsyncLocalStorageService,

--- a/apps/gd-main-app/src/modules/auth/constants/cookie-options.constants.ts
+++ b/apps/gd-main-app/src/modules/auth/constants/cookie-options.constants.ts
@@ -1,0 +1,6 @@
+export const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: true,
+  sameSite: 'lax' as const,
+  path: '/',
+};

--- a/apps/gd-main-app/src/modules/auth/interface/auth.controller.ts
+++ b/apps/gd-main-app/src/modules/auth/interface/auth.controller.ts
@@ -3,11 +3,12 @@ import {
   Controller,
   HttpCode,
   HttpStatus,
-  Post,
+  Post, Res,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { CommandBus } from '@nestjs/cqrs';
+import type { Response } from 'express';
 import { UserInputDto } from '../../users/interface/dto/user.input.dto';
 import { RegistrationCommand } from '../application/use-cases/registration.use.case';
 import { RegistrationSwagger } from '../../../../core/decorators/swagger-settings/registration.swagger.decorator';
@@ -20,6 +21,9 @@ import { LocalAuthGuard } from '../../../../core/guards/local/local.auth.guard';
 import { CookieInterceptor } from '../../../../core/interceptors/refresh-cookie.interceptor';
 import { TokenResponseDto } from '../../../../core/types/token.types';
 import { LoginSwagger } from '../../../../core/decorators/swagger-settings/login.swagger.decorator';
+import { LogoutSwagger } from '../../../../core/decorators/swagger-settings/logout.swagger.decorator';
+import { JwtAuthGuard } from '../../../../core/guards/local/jwt-auth-guard';
+import { COOKIE_OPTIONS } from '../constants/cookie-options.constants';
 
 @Controller('auth')
 export class AuthController {
@@ -47,5 +51,14 @@ export class AuthController {
     }
 
     return new TokenResponseDto(tokens.accessToken, tokens.refreshToken);
+  }
+
+  @Post('logout')
+  @LogoutSwagger()
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async logout(@Res() res: Response) {
+    res.clearCookie('refreshToken', COOKIE_OPTIONS);
+    res.sendStatus(HttpStatus.NO_CONTENT);
   }
 }

--- a/apps/gd-main-app/test/auth-tests/logout.integration.spec.ts
+++ b/apps/gd-main-app/test/auth-tests/logout.integration.spec.ts
@@ -1,0 +1,181 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PassportModule } from '@nestjs/passport';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { AuthController } from '../../src/modules/auth/interface/auth.controller';
+import { AuthService } from '../../src/modules/auth/application/auth.service';
+import { LocalStrategy } from '../../core/guards/local/local.strategy';
+import { LocalAuthGuard } from '../../core/guards/local/local.auth.guard';
+import { JwtStrategy } from '../../core/guards/local/jwt.strategy';
+import { JwtAuthGuard } from '../../core/guards/local/jwt-auth-guard';
+import { UsersRepository } from '../../src/modules/users/infrastructure/users.repository';
+import { CryptoService } from '../../src/modules/users/application/crypto.service';
+import { TokenService } from '../../src/modules/auth/application/use-cases/token.service';
+import { CommandBus } from '@nestjs/cqrs';
+import { AppConfigService, NotificationService } from '@common';
+
+import request from 'supertest';
+import {
+  MockAppNotification,
+  MockCommandBus,
+  MockFactory,
+  MockNotificationService,
+} from '../mocks/common.mocks';
+import {
+  MockUsersRepository,
+  MockUser,
+} from '../mocks/user.flow.mocks';
+import {
+  MockCryptoService,
+  MockTokenService,
+} from '../mocks/auth.flow.mocks';
+
+describe('AuthController - Logout Integration Tests', () => {
+  let app: INestApplication;
+  let usersRepository: MockUsersRepository;
+  let cryptoService: MockCryptoService;
+  let commandBus: MockCommandBus;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        PassportModule,
+        JwtModule.register({
+          secret: 'test-secret',
+          signOptions: { expiresIn: '1h' },
+        }),
+      ],
+      controllers: [AuthController],
+      providers: [
+        AuthService,
+        LocalStrategy,
+        LocalAuthGuard,
+        JwtStrategy,
+        JwtAuthGuard,
+        {
+          provide: UsersRepository,
+          useClass: MockUsersRepository,
+        },
+        {
+          provide: CryptoService,
+          useClass: MockCryptoService,
+        },
+        {
+          provide: TokenService,
+          useClass: MockTokenService,
+        },
+        {
+          provide: CommandBus,
+          useClass: MockCommandBus,
+        },
+        {
+          provide: NotificationService,
+          useClass: MockNotificationService,
+        },
+        {
+          provide: AppConfigService,
+          useValue: {
+            jwtAccessSecret: 'test-secret',
+          },
+        },
+        JwtService,
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+
+    await app.init();
+
+    usersRepository = module.get<MockUsersRepository>(UsersRepository);
+    cryptoService = module.get<MockCryptoService>(CryptoService);
+    commandBus = module.get<MockCommandBus>(CommandBus);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    jest.clearAllMocks();
+  });
+
+  const validLoginData = {
+    email: 'test@example.com',
+    password: 'ValidPassword123!',
+  };
+
+  const setupLoginFlow = () => {
+    const mockUser: MockUser = MockFactory.createUser(
+      1,
+      'testuser',
+      validLoginData.email,
+      'hashedPassword123',
+      true,
+    );
+
+    const mockTokens = MockFactory.createTokens(
+      'mock-access-token',
+      'mock-refresh-token',
+    );
+
+    const mockNotification: MockAppNotification<any> =
+      MockFactory.createSuccessNotification(mockTokens);
+
+    usersRepository.findByUsernameOrEmail.mockResolvedValue(mockUser);
+    cryptoService.comparePassword.mockResolvedValue(true);
+    commandBus.execute.mockResolvedValue(mockNotification);
+  };
+
+  const loginAndGetCookies = async () => {
+    setupLoginFlow();
+
+    const jwtService = app.get(JwtService);
+    const accessToken = jwtService.sign({ id: 1 });
+
+    const res = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send(validLoginData)
+      .expect(200);
+
+    return {
+      cookies: res.headers['set-cookie'],
+      accessToken,
+    };
+  };
+
+  describe('POST /auth/logout', () => {
+    it('should clear refreshToken cookie and return 204', async () => {
+      const { cookies, accessToken } = await loginAndGetCookies();
+
+      const response = await request(app.getHttpServer())
+        .post('/auth/logout')
+        .set('Cookie', cookies)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .expect(204);
+
+      const setCookie = response.headers['set-cookie'];
+      expect(setCookie).toBeDefined();
+      expect(setCookie[0]).toMatch(/refreshToken=;/);
+      expect(setCookie[0]).toContain('HttpOnly');
+      expect(setCookie[0]).toContain('Secure');
+      expect(setCookie[0]).toContain('SameSite=Lax');
+    });
+
+    it('should return 401 if no token provided', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/auth/logout')
+        .expect(401);
+
+      expect(response.body).toEqual({
+        statusCode: 401,
+        message: 'Unauthorized',
+      });
+    });
+
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@types/jest": "^29.5.14",
     "@types/joi": "^17.2.3",
     "@types/node": "^22.10.7",
+    "@types/passport-jwt": "^4.0.1",
     "@types/passport-local": "^1.0.38",
     "@types/pg": "^8.15.4",
     "@types/supertest": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@types/node':
         specifier: ^22.10.7
         version: 22.15.32
+      '@types/passport-jwt':
+        specifier: ^4.0.1
+        version: 4.0.1
       '@types/passport-local':
         specifier: ^1.0.38
         version: 1.0.38
@@ -1518,6 +1521,9 @@ packages:
 
   '@types/node@22.15.32':
     resolution: {integrity: sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==}
+
+  '@types/passport-jwt@4.0.1':
+    resolution: {integrity: sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==}
 
   '@types/passport-local@1.0.38':
     resolution: {integrity: sha512-nsrW4A963lYE7lNTv9cr5WmiUD1ibYJvWrpE13oxApFsRt77b0RdtZvKbCdNIY4v/QZ6TRQWaDDEwV1kCTmcXg==}
@@ -6550,6 +6556,11 @@ snapshots:
   '@types/node@22.15.32':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/passport-jwt@4.0.1':
+    dependencies:
+      '@types/jsonwebtoken': 9.0.7
+      '@types/passport-strategy': 0.2.38
 
   '@types/passport-local@1.0.38':
     dependencies:


### PR DESCRIPTION
- Implement `JwtAuthGuard` and `JwtStrategy` for validating JWTs.
- Integrate logout endpoint in `AuthController` with cookie clearance using `COOKIE_OPTIONS`.
- Add Swagger decorators for logout API documentation.
- Write integration tests for logout functionality in `AuthController`.
- Update dependencies to include `@types/passport-jwt`.