### PR TITLE
feat(devices): extend `/devices` endpoint with session ID support and…

### DIFF
--- a/apps/gd-main-app/core/decorators/swagger-settings/devices/all.user.devices.decorator.ts
+++ b/apps/gd-main-app/core/decorators/swagger-settings/devices/all.user.devices.decorator.ts
@@ -1,20 +1,27 @@
-import { applyDecorators } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { applyDecorators, HttpStatus } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 
-import { DeviceEntity } from '../../../../src/modules/devices/domain/device.entity';
+import { ErrorResponseDto } from '@common';
+
+import { DeviceViewDto } from '../../../../src/modules/devices/interface/dto/output/device.view.dto';
 
 export function AllUserDevicesSwagger() {
   return applyDecorators(
-    ApiBearerAuth(),
+    ApiCookieAuth('refreshToken'),
     ApiOperation({
       summary: 'Get all user devices',
       description:
         'This endpoint retrieves all devices associated with the authenticated user.',
     }),
     ApiResponse({
-      status: 200,
+      status: HttpStatus.UNAUTHORIZED,
+      type: ErrorResponseDto,
+      description: 'User is not authenticated or token is invalid.',
+    }),
+    ApiResponse({
+      status: HttpStatus.OK,
       description: 'Successfully retrieved all user devices.',
-      type: DeviceEntity,
+      type: DeviceViewDto,
     }),
   );
 }

--- a/apps/gd-main-app/src/modules/devices/domain/device.entity.ts
+++ b/apps/gd-main-app/src/modules/devices/domain/device.entity.ts
@@ -56,6 +56,7 @@ export class DeviceEntity extends BasicEntity {
       deviceName: device.deviceName,
       deviceId: device.id,
       ip: device.ip,
+      sessionId: device.sessionId,
       updatedAt: device.updatedAt,
     };
   }

--- a/apps/gd-main-app/src/modules/devices/interface/device.controller.ts
+++ b/apps/gd-main-app/src/modules/devices/interface/device.controller.ts
@@ -21,8 +21,8 @@ export class DeviceController {
   ) {}
 
   @Get()
+  @UseGuards(RefreshGuard)
   @AllUserDevicesSwagger()
-  @UseGuards(JwtAuthGuard)
   async getAllUserDevices(@ExtractUserFromRequest() user: UserContextDto) {
     return await this.devicesQueryRepository.findSessionsByUserId(user.id);
   }

--- a/apps/gd-main-app/src/modules/devices/interface/dto/output/device.view.dto.ts
+++ b/apps/gd-main-app/src/modules/devices/interface/dto/output/device.view.dto.ts
@@ -29,6 +29,12 @@ export class DeviceViewDto {
   ip: string | null;
 
   @ApiProperty({
+    description: 'Session ID associated with the device.',
+    example: 'd67d5893-ab05-4c1e-b866-f4c8494ca03f',
+  })
+  sessionId: string;
+
+  @ApiProperty({
     description: 'Date and time when the device was last updated.',
     example: '2023-10-02T12:00:00Z',
     nullable: true,

--- a/apps/gd-main-app/test/devices-tests/get-devices.integration.spec.ts
+++ b/apps/gd-main-app/test/devices-tests/get-devices.integration.spec.ts
@@ -1,0 +1,239 @@
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { PassportModule } from '@nestjs/passport';
+import { CqrsModule } from '@nestjs/cqrs';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+
+import { AppConfigService, NotificationInterceptor, NotificationService } from '@common';
+import { AsyncLocalStorageService, CustomLogger } from '@monitoring';
+
+import { MockDevicesQueryRepository, MockDevicesRepository } from '../mocks/devices.flow.mocks';
+import { MockAppConfigService } from '../mocks/common.mocks';
+
+import { DevicesRepository } from '../../src/modules/devices/infrastructure/devices.repository';
+import { DevicesQueryRepository } from '../../src/modules/devices/infrastructure/devices.query.repository';
+
+import { DeviceController } from '../../src/modules/devices/interface/device.controller';
+
+import { TokenService } from '../../src/modules/auth/application/use-cases/token.service';
+
+import { JwtRefreshStrategy } from '../../core/guards/refresh/jwt.refresh.strategy';
+
+import { RefreshGuard } from '../../core/guards/refresh/jwt.refresh.auth.guard';
+
+import { DeleteOtherDevicesUseCase } from '../../src/modules/devices/application/delete.device.use.case';
+
+describe('DevicesController - Get Devices Integration Tests', () => {
+  let app: INestApplication;
+  let devicesQueryRepository: MockDevicesQueryRepository;
+  let jwtService: JwtService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [PassportModule, JwtModule.register({}), CqrsModule],
+      controllers: [DeviceController],
+      providers: [
+        DeleteOtherDevicesUseCase,
+        TokenService,
+        NotificationService,
+        NotificationInterceptor,
+        {
+          provide: CustomLogger,
+          useValue: {
+            setContext: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+            log: jest.fn(),
+          },
+        },
+
+        {
+          provide: DevicesRepository,
+          useClass: MockDevicesRepository,
+        },
+        {
+          provide: DevicesQueryRepository,
+          useClass: MockDevicesQueryRepository,
+        },
+
+        JwtRefreshStrategy,
+        RefreshGuard,
+        JwtService,
+        {
+          provide: AppConfigService,
+          useClass: MockAppConfigService,
+        },
+
+        {
+          provide: AsyncLocalStorageService,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+    app.useGlobalInterceptors(new NotificationInterceptor());
+    app.use(cookieParser());
+    await app.init();
+
+    devicesQueryRepository =
+      module.get<MockDevicesQueryRepository>(DevicesQueryRepository);
+    jwtService = module.get<JwtService>(JwtService);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    jest.clearAllMocks();
+  });
+
+  describe('GET /devices', () => {
+    it('200 - should successfully retrieve user devices', async () => {
+      const userId = 1;
+      const currentSessionId = 'current-session-123';
+
+      const refreshTokenPayload = {
+        id: userId,
+        sessionId: currentSessionId,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      const validRefreshToken = jwtService.sign(refreshTokenPayload, {
+        secret: 'testRefreshSecret',
+      });
+
+      const refreshCookie = `refreshToken=${validRefreshToken}; SameSite=lax; HttpOnly`;
+
+      const now = new Date().toISOString();
+
+      const mockDevices = [
+        {
+          deviceId: 1,
+          userId: userId,
+          deviceName: 'iPhone 12',
+          ip: '192.168.1.1',
+          sessionId: 'session-1',
+          updatedAt: now,
+        },
+        {
+          deviceId: 2,
+          userId: userId,
+          deviceName: 'MacBook Pro',
+          ip: '192.168.1.2',
+          sessionId: 'session-2',
+          updatedAt: now,
+        },
+      ];
+
+      devicesQueryRepository.findSessionsByUserId.mockResolvedValue(mockDevices);
+
+      const response = await request(app.getHttpServer())
+        .get('/devices')
+        .set('Cookie', refreshCookie)
+        .expect(200);
+
+      expect(devicesQueryRepository.findSessionsByUserId).toHaveBeenCalledWith(userId);
+      expect(response.body).toEqual(mockDevices);
+    });
+
+    it('200 - should return empty array when user has no devices', async () => {
+      const userId = 1;
+      const currentSessionId = 'current-session-123';
+
+      const refreshTokenPayload = {
+        id: userId,
+        sessionId: currentSessionId,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      const validRefreshToken = jwtService.sign(refreshTokenPayload, {
+        secret: 'testRefreshSecret',
+      });
+
+      const refreshCookie = `refreshToken=${validRefreshToken}; SameSite=lax; HttpOnly`;
+
+      devicesQueryRepository.findSessionsByUserId.mockResolvedValue([]);
+
+      const response = await request(app.getHttpServer())
+        .get('/devices')
+        .set('Cookie', refreshCookie)
+        .expect(200);
+
+      expect(devicesQueryRepository.findSessionsByUserId).toHaveBeenCalledWith(userId);
+      expect(response.body).toEqual([]);
+    });
+
+    it('401 - should return unauthorized when refresh token is missing', async () => {
+      await request(app.getHttpServer()).get('/devices').expect(401);
+
+      expect(devicesQueryRepository.findSessionsByUserId).not.toHaveBeenCalled();
+    });
+
+    it('401 - should return unauthorized when refresh token is invalid', async () => {
+      const invalidCookie = 'refreshToken=invalid-token; HttpOnly; SameSite=lax';
+
+      await request(app.getHttpServer())
+        .get('/devices')
+        .set('Cookie', invalidCookie)
+        .expect(401);
+
+      expect(devicesQueryRepository.findSessionsByUserId).not.toHaveBeenCalled();
+    });
+
+    it('401 - should return unauthorized when refresh token is expired', async () => {
+      const expiredPayload = {
+        id: 1,
+        sessionId: 'session-123',
+        iat: Math.floor(Date.now() / 1000) - 3600,
+        exp: Math.floor(Date.now() / 1000) - 1800,
+      };
+
+      const expiredRefreshToken = jwtService.sign(expiredPayload, {
+        secret: 'testRefreshSecret',
+      });
+
+      const expiredCookie = `refreshToken=${expiredRefreshToken}; HttpOnly; SameSite=lax`;
+
+      await request(app.getHttpServer())
+        .get('/devices')
+        .set('Cookie', expiredCookie)
+        .expect(401);
+
+      expect(devicesQueryRepository.findSessionsByUserId).not.toHaveBeenCalled();
+    });
+
+    it('401 - should return unauthorized when token payload is incomplete (missing sessionId)', async () => {
+      const incompletePayload = {
+        id: 1,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      const incompleteToken = jwtService.sign(incompletePayload, {
+        secret: 'testRefreshSecret',
+      });
+
+      const incompleteCookie = `refreshToken=${incompleteToken}; HttpOnly; SameSite=lax`;
+
+      await request(app.getHttpServer())
+        .get('/devices')
+        .set('Cookie', incompleteCookie)
+        .expect(401);
+
+      expect(devicesQueryRepository.findSessionsByUserId).not.toHaveBeenCalled();
+    });
+  });
+})

--- a/apps/gd-main-app/test/mocks/devices.flow.mocks.ts
+++ b/apps/gd-main-app/test/mocks/devices.flow.mocks.ts
@@ -11,4 +11,5 @@ export class MockDevicesRepository {
 export class MockDevicesQueryRepository {
   findByUserId = jest.fn();
   findActiveDevices = jest.fn();
+  findSessionsByUserId = jest.fn();
 }


### PR DESCRIPTION
- Integration tests
- Updated `DeviceViewDto` to include `sessionId` property for better session tracking.
- Enhanced `AllUserDevicesSwagger` decorator with updated responses and cookie authentication (`ApiCookieAuth`).
- Replaced `JwtAuthGuard` with `RefreshGuard` in `DeviceController`.
- Added integration tests to validate `/devices` endpoint functionality, including various authentication scenarios.
- Updated mocks and repositories to support `findSessionsByUserId` method.