### PR TITLE
feat(devices): add delete device by session ID functionality with int…

### DIFF
--- a/apps/gd-main-app/core/decorators/swagger-settings/devices/all.user.devices.swagger.decorator.ts
+++ b/apps/gd-main-app/core/decorators/swagger-settings/devices/all.user.devices.swagger.decorator.ts
@@ -23,5 +23,5 @@ export function AllUserDevicesSwagger() {
       description: 'Successfully retrieved all user devices.',
       type: DeviceViewDto,
     }),
-  );
+  )
 }

--- a/apps/gd-main-app/core/decorators/swagger-settings/devices/delete.device.by.session.id.swagger.decorator.ts
+++ b/apps/gd-main-app/core/decorators/swagger-settings/devices/delete.device.by.session.id.swagger.decorator.ts
@@ -1,0 +1,31 @@
+import { applyDecorators, HttpStatus } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
+
+export function DeleteDeviceBySessionIdSwagger() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'Delete device by session ID',
+      description:
+        'This endpoint allows the user to delete a specific device session by providing its session ID.',
+    }),
+    ApiCookieAuth('refreshToken'),
+    ApiParam({
+      name: 'sessionId',
+      description: 'ID of the device session to delete',
+      required: true,
+      type: String,
+    }),
+    ApiResponse({
+      status: HttpStatus.NO_CONTENT,
+      description: 'Device session deleted successfully.',
+    }),
+    ApiResponse({
+      status: HttpStatus.UNAUTHORIZED,
+      description: 'User is not authenticated or token is invalid.',
+    }),
+    ApiResponse({
+      status: HttpStatus.NOT_FOUND,
+      description: 'Device session not found.',
+    })
+  )
+}

--- a/apps/gd-main-app/src/modules/auth/application/use-cases/refresh.token.use-case.ts
+++ b/apps/gd-main-app/src/modules/auth/application/use-cases/refresh.token.use-case.ts
@@ -45,10 +45,3 @@ export class RefreshTokenUseCase implements ICommandHandler<RefreshTokenCommand>
     return notify.setValue(tokens);
   }
 }
-export type DeviceDomainDto = {
-  userId: number;
-  ip: string;
-  deviceName: string;
-  tokenVersion: string;
-  sessionId: string;
-};

--- a/apps/gd-main-app/src/modules/devices/application/delete.device.by.session.id.use.case.ts
+++ b/apps/gd-main-app/src/modules/devices/application/delete.device.by.session.id.use.case.ts
@@ -1,0 +1,39 @@
+import { UserContextDto } from '../../../../core/dto/user.context.dto';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { DevicesRepository } from '../infrastructure/devices.repository';
+import { NotificationService } from '@common';
+import { CustomLogger } from '@monitoring';
+
+
+export class DeleteDeviceBySessionIdCommand {
+  constructor(
+    public readonly userId: UserContextDto['id'],
+    public readonly sessionId: string,
+  ) {}
+}
+
+@CommandHandler(DeleteDeviceBySessionIdCommand)
+export class DeleteDeviceBySessionIdUseCase implements
+  ICommandHandler<DeleteDeviceBySessionIdCommand> {
+  constructor(
+    private readonly devicesRepository: DevicesRepository,
+    private readonly notification: NotificationService,
+    private readonly logger: CustomLogger,
+  ) {
+    this.logger.setContext('Delete Other Devices use case');
+  }
+
+  async execute(command: DeleteDeviceBySessionIdCommand) {
+    const notify = this.notification.create();
+    const device = await this.devicesRepository.findSessionBySessionIdAndUserId(
+      command.sessionId,
+      command.userId
+    )
+
+    if (!device) {
+      this.logger.warn('Device not found');
+      return notify.setNotFound('Device not found');
+    }
+    await this.devicesRepository.deleteDevice(device);
+  }
+}

--- a/apps/gd-main-app/src/modules/devices/device.module.ts
+++ b/apps/gd-main-app/src/modules/devices/device.module.ts
@@ -14,6 +14,9 @@ import { CqrsModule } from '@nestjs/cqrs';
 import { NotificationService } from '@common';
 import { AsyncLocalStorageService } from '@monitoring';
 import { PassportModule } from '@nestjs/passport';
+import {
+  DeleteDeviceBySessionIdUseCase,
+} from './application/delete.device.by.session.id.use.case';
 
 @Module({
   imports: [
@@ -27,6 +30,7 @@ import { PassportModule } from '@nestjs/passport';
     DevicesRepository,
     UpdateDeviceUseCase,
     DeleteOtherDevicesUseCase,
+    DeleteDeviceBySessionIdUseCase,
     NotificationService,
     AsyncLocalStorageService,
   ],

--- a/apps/gd-main-app/src/modules/devices/interface/device.controller.ts
+++ b/apps/gd-main-app/src/modules/devices/interface/device.controller.ts
@@ -1,17 +1,23 @@
-import { Controller, Delete, Get, HttpCode, HttpStatus, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Get, HttpCode, HttpStatus, Param, UseGuards } from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
 
 import { JwtAuthGuard } from '../../../../core/guards/local/jwt-auth-guard';
 
 import { ExtractUserFromRequest } from '../../../../core/decorators/guard-decorators/extract.user.from.request.decorator';
-import { AllUserDevicesSwagger } from '../../../../core/decorators/swagger-settings/devices/all.user.devices.decorator';
+import { AllUserDevicesSwagger } from '../../../../core/decorators/swagger-settings/devices/all.user.devices.swagger.decorator';
 
 import { UserContextDto } from '../../../../core/dto/user.context.dto';
 
 import { DevicesQueryRepository } from '../infrastructure/devices.query.repository';
-import { CommandBus } from '@nestjs/cqrs';
+
 import { DeleteOtherDevicesCommand } from '../application/delete.device.use.case';
+import { DeleteDeviceBySessionIdCommand } from '../application/delete.device.by.session.id.use.case';
+
 import { RefreshGuard } from '../../../../core/guards/refresh/jwt.refresh.auth.guard';
 import { DeleteOtherDevicesSwagger } from '../../../../core/decorators/swagger-settings/devices/delete.devices.swagger.decorator';
+import {
+  DeleteDeviceBySessionIdSwagger
+} from '../../../../core/decorators/swagger-settings/devices/delete.device.by.session.id.swagger.decorator';
 
 @Controller('devices')
 export class DeviceController {
@@ -35,5 +41,21 @@ export class DeviceController {
     return await this.commandBus.execute(
       new DeleteOtherDevicesCommand(user.id, user.sessionId),
     );
+  }
+
+  @Delete(':sessionId')
+  @UseGuards(RefreshGuard)
+  @DeleteDeviceBySessionIdSwagger()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async terminateSessionById(
+    @Param('sessionId') sessionId: string,
+    @ExtractUserFromRequest() user: UserContextDto
+  ) {
+    return await this.commandBus.execute(
+      new DeleteDeviceBySessionIdCommand(
+        user.id,
+        sessionId
+      )
+    )
   }
 }

--- a/apps/gd-main-app/test/devices-tests/delete.session.by.id.integration.spec.ts
+++ b/apps/gd-main-app/test/devices-tests/delete.session.by.id.integration.spec.ts
@@ -1,0 +1,287 @@
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PassportModule } from '@nestjs/passport';
+import { CqrsModule } from '@nestjs/cqrs';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+
+import { AppConfigService, NotificationInterceptor, NotificationService } from '@common';
+import { AsyncLocalStorageService, CustomLogger } from '@monitoring';
+
+import { MockDevicesQueryRepository, MockDevicesRepository } from '../mocks/devices.flow.mocks';
+
+import { DeviceController } from '../../src/modules/devices/interface/device.controller';
+
+import { TokenService } from '../../src/modules/auth/application/use-cases/token.service';
+
+import { DevicesRepository } from '../../src/modules/devices/infrastructure/devices.repository';
+import { DevicesQueryRepository } from '../../src/modules/devices/infrastructure/devices.query.repository';
+
+import { JwtRefreshStrategy } from '../../core/guards/refresh/jwt.refresh.strategy';
+
+import { RefreshGuard } from '../../core/guards/refresh/jwt.refresh.auth.guard';
+
+import { MockAppConfigService } from '../mocks/common.mocks';
+
+import {
+  DeleteDeviceBySessionIdUseCase
+} from '../../src/modules/devices/application/delete.device.by.session.id.use.case';
+
+describe('DeviceController - Delete Session By ID Integration Tests', () => {
+  let app: INestApplication;
+  let devicesRepository: MockDevicesRepository;
+  let devicesQueryRepository: MockDevicesQueryRepository;
+  let jwtService: JwtService;
+  let notificationService: NotificationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [PassportModule, JwtModule.register({}), CqrsModule],
+      controllers: [DeviceController],
+      providers: [
+        DeleteDeviceBySessionIdUseCase,
+        TokenService,
+        NotificationService,
+        NotificationInterceptor,
+        {
+          provide: CustomLogger,
+          useValue: {
+            setContext: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+            log: jest.fn(),
+          },
+        },
+
+        {
+          provide: DevicesRepository,
+          useClass: MockDevicesRepository,
+        },
+        {
+          provide: DevicesQueryRepository,
+          useClass: MockDevicesQueryRepository,
+        },
+
+        JwtRefreshStrategy,
+        RefreshGuard,
+        JwtService,
+        {
+          provide: AppConfigService,
+          useClass: MockAppConfigService,
+        },
+
+        {
+          provide: AsyncLocalStorageService,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    );
+    app.useGlobalInterceptors(new NotificationInterceptor());
+    app.use(cookieParser());
+    await app.init();
+
+    devicesRepository = module.get<MockDevicesRepository>(DevicesRepository);
+    devicesQueryRepository =
+      module.get<MockDevicesQueryRepository>(DevicesQueryRepository);
+    jwtService = module.get<JwtService>(JwtService);
+    notificationService = module.get<NotificationService>(NotificationService);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    jest.clearAllMocks();
+  });
+
+  describe('DELETE /devices/:sessionId', () => {
+    it('204 - should successfully delete session by ID', async () => {
+      const userId = 1;
+      const currentSessionId = 'current-session-123';
+      const sessionIdToDelete = 'session-to-delete-456';
+
+      const refreshTokenPayload = {
+        id: userId,
+        sessionId: currentSessionId,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      const validRefreshToken = jwtService.sign(refreshTokenPayload, {
+        secret: 'testRefreshSecret',
+      });
+
+      const refreshCookie = `refreshToken=${validRefreshToken}; SameSite=lax; HttpOnly`;
+
+      const mockDevice = {
+        id: 2,
+        userId: userId,
+        sessionId: sessionIdToDelete,
+        deviceName: 'MacBook Pro',
+        ip: '192.168.1.2',
+        updatedAt: new Date(),
+      };
+
+      devicesRepository.findSessionBySessionIdAndUserId.mockResolvedValue(mockDevice);
+      devicesRepository.deleteDevice.mockResolvedValue(undefined);
+
+      const response = await request(app.getHttpServer())
+        .delete(`/devices/${sessionIdToDelete}`)
+        .set('Cookie', refreshCookie)
+        .expect(204);
+
+      expect(devicesRepository.findSessionBySessionIdAndUserId).toHaveBeenCalledWith(
+        sessionIdToDelete,
+        userId
+      );
+      expect(devicesRepository.deleteDevice).toHaveBeenCalledWith(mockDevice);
+      expect(response.body).toEqual({});
+    });
+
+    it('404 - should return not found when session does not exist', async () => {
+      const userId = 1;
+      const currentSessionId = 'current-session-123';
+      const nonExistentSessionId = 'non-existent-session';
+
+      const refreshTokenPayload = {
+        id: userId,
+        sessionId: currentSessionId,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      const validRefreshToken = jwtService.sign(refreshTokenPayload, {
+        secret: 'testRefreshSecret',
+      });
+
+      const refreshCookie = `refreshToken=${validRefreshToken}; SameSite=lax; HttpOnly`;
+
+      devicesRepository.findSessionBySessionIdAndUserId.mockResolvedValue(null);
+
+      await request(app.getHttpServer())
+        .delete(`/devices/${nonExistentSessionId}`)
+        .set('Cookie', refreshCookie)
+        .expect(404);
+
+      expect(devicesRepository.findSessionBySessionIdAndUserId).toHaveBeenCalledWith(
+        nonExistentSessionId,
+        userId
+      );
+      expect(devicesRepository.deleteDevice).not.toHaveBeenCalled();
+    });
+
+    it('401 - should return unauthorized when refresh token is missing', async () => {
+      const sessionIdToDelete = 'session-to-delete-456';
+
+      await request(app.getHttpServer())
+        .delete(`/devices/${sessionIdToDelete}`)
+        .expect(401);
+
+      expect(devicesRepository.findSessionBySessionIdAndUserId).not.toHaveBeenCalled();
+      expect(devicesRepository.deleteDevice).not.toHaveBeenCalled();
+    });
+
+    it('401 - should return unauthorized when refresh token is invalid', async () => {
+      const sessionIdToDelete = 'session-to-delete-456';
+      const invalidCookie = 'refreshToken=invalid-token; HttpOnly; SameSite=lax';
+
+      await request(app.getHttpServer())
+        .delete(`/devices/${sessionIdToDelete}`)
+        .set('Cookie', invalidCookie)
+        .expect(401);
+
+      expect(devicesRepository.findSessionBySessionIdAndUserId).not.toHaveBeenCalled();
+      expect(devicesRepository.deleteDevice).not.toHaveBeenCalled();
+    });
+
+    it('401 - should return unauthorized when refresh token is expired', async () => {
+      const sessionIdToDelete = 'session-to-delete-456';
+      const expiredPayload = {
+        id: 1,
+        sessionId: 'session-123',
+        iat: Math.floor(Date.now() / 1000) - 3600,
+        exp: Math.floor(Date.now() / 1000) - 1800,
+      };
+
+      const expiredRefreshToken = jwtService.sign(expiredPayload, {
+        secret: 'testRefreshSecret',
+      });
+
+      const expiredCookie = `refreshToken=${expiredRefreshToken}; HttpOnly; SameSite=lax`;
+
+      await request(app.getHttpServer())
+        .delete(`/devices/${sessionIdToDelete}`)
+        .set('Cookie', expiredCookie)
+        .expect(401);
+
+      expect(devicesRepository.findSessionBySessionIdAndUserId).not.toHaveBeenCalled();
+      expect(devicesRepository.deleteDevice).not.toHaveBeenCalled();
+    });
+
+    it('401 - should return unauthorized when token payload is incomplete (missing sessionId)', async () => {
+      const sessionIdToDelete = 'session-to-delete-456';
+      const incompletePayload = {
+        id: 1,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      const incompleteToken = jwtService.sign(incompletePayload, {
+        secret: 'testRefreshSecret',
+      });
+
+      const incompleteCookie = `refreshToken=${incompleteToken}; HttpOnly; SameSite=lax`;
+
+      await request(app.getHttpServer())
+        .delete(`/devices/${sessionIdToDelete}`)
+        .set('Cookie', incompleteCookie)
+        .expect(401);
+
+      expect(devicesRepository.findSessionBySessionIdAndUserId).not.toHaveBeenCalled();
+      expect(devicesRepository.deleteDevice).not.toHaveBeenCalled();
+    });
+
+    it('404 - should return not found when trying to delete another user\'s session', async () => {
+      const userId = 1;
+      const currentSessionId = 'current-session-123';
+      const anotherUserSessionId = 'another-user-session';
+
+      const refreshTokenPayload = {
+        id: userId,
+        sessionId: currentSessionId,
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      };
+
+      const validRefreshToken = jwtService.sign(refreshTokenPayload, {
+        secret: 'testRefreshSecret',
+      });
+
+      const refreshCookie = `refreshToken=${validRefreshToken}; SameSite=lax; HttpOnly`;
+
+      devicesRepository.findSessionBySessionIdAndUserId.mockResolvedValue(null);
+
+      await request(app.getHttpServer())
+        .delete(`/devices/${anotherUserSessionId}`)
+        .set('Cookie', refreshCookie)
+        .expect(404);
+
+      expect(devicesRepository.findSessionBySessionIdAndUserId).toHaveBeenCalledWith(
+        anotherUserSessionId,
+        userId
+      );
+      expect(devicesRepository.deleteDevice).not.toHaveBeenCalled();
+    });
+  });
+})


### PR DESCRIPTION
- integration tests
- Implemented `DeleteDeviceBySessionIdUseCase` to handle deletion of device sessions by session ID.
- Extended `DeviceController` with a new `DELETE /devices/:sessionId` endpoint.
- Added `DeleteDeviceBySessionIdSwagger` decorator for comprehensive API documentation.
- Included integration tests to validate delete session functionality across various scenarios.
- Updated `DeviceModule` to register `DeleteDeviceBySessionIdUseCase`.